### PR TITLE
ci(fix): replace deprecated `::set-output` with append to $GITHUB_OUTPUT

### DIFF
--- a/.github/workflows/cookiecutter.yml
+++ b/.github/workflows/cookiecutter.yml
@@ -40,8 +40,8 @@ jobs:
         run: |
           CURRENT_VERSION=$(git show HEAD:.cruft.json | jello -r "_['commit'][:8]")
           NEXT_VERSION=$(jello -r "_['commit'][:8]" < .cruft.json)
-          echo "current_version=$CURRENT_VERSION" >> $GITHUB_OUTPUT
-          echo "next_version=$NEXT_VERSION" >> $GITHUB_OUTPUT
+          echo "current_version=$CURRENT_VERSION" >> "$GITHUB_OUTPUT"
+          echo "next_version=$NEXT_VERSION" >> "$GITHUB_OUTPUT"
 
       - name: Get changelog
         id: get_changelog
@@ -61,7 +61,7 @@ jobs:
           body="${body//'%'/'%25'}"
           body="${body//$'\n'/'%0A'}"
           body="${body//$'\r'/'%0D'}"
-          echo "body=$body" >> $GITHUB_OUTPUT
+          echo "body=$body" >> "$GITHUB_OUTPUT"
 
       # behaviour if PR already exists: https://github.com/marketplace/actions/create-pull-request#action-behaviour
       - name: Create Pull Request

--- a/.github/workflows/cookiecutter.yml
+++ b/.github/workflows/cookiecutter.yml
@@ -22,7 +22,9 @@ jobs:
 
       - name: Check if there are changes
         id: changes
-        run: echo "::set-output name=changed::$(git status --porcelain | wc -l)"
+        run: |
+          changed=$(git status --porcelain | wc -l)
+          echo "changed=$changed" >> $GITHUB_OUTPUT
 
       - name: apply additional changes and fixes
         if: steps.changes.outputs.changed > 0
@@ -38,8 +40,8 @@ jobs:
         run: |
           CURRENT_VERSION=$(git show HEAD:.cruft.json | jello -r "_['commit'][:8]")
           NEXT_VERSION=$(jello -r "_['commit'][:8]" < .cruft.json)
-          echo ::set-output name="current_version::$CURRENT_VERSION"
-          echo ::set-output name="next_version::$NEXT_VERSION"
+          echo "current_version=$CURRENT_VERSION" >> $GITHUB_OUTPUT
+          echo "next_version=$NEXT_VERSION" >> $GITHUB_OUTPUT
 
       - name: Get changelog
         id: get_changelog
@@ -59,7 +61,7 @@ jobs:
           body="${body//'%'/'%25'}"
           body="${body//$'\n'/'%0A'}"
           body="${body//$'\r'/'%0D'}"
-          echo ::set-output name="changelog::$body"
+          echo "body=$body" >> $GITHUB_OUTPUT
 
       # behaviour if PR already exists: https://github.com/marketplace/actions/create-pull-request#action-behaviour
       - name: Create Pull Request

--- a/.github/workflows/cookiecutter.yml
+++ b/.github/workflows/cookiecutter.yml
@@ -24,7 +24,7 @@ jobs:
         id: changes
         run: |
           changed="$(git status --porcelain | wc -l)"
-          echo "changed=$changed" >> $GITHUB_OUTPUT
+          echo "changed=$changed" >> "$GITHUB_OUTPUT"
 
       - name: apply additional changes and fixes
         if: steps.changes.outputs.changed > 0

--- a/.github/workflows/cookiecutter.yml
+++ b/.github/workflows/cookiecutter.yml
@@ -23,7 +23,7 @@ jobs:
       - name: Check if there are changes
         id: changes
         run: |
-          changed=$(git status --porcelain | wc -l)
+          changed="$(git status --porcelain | wc -l)"
           echo "changed=$changed" >> $GITHUB_OUTPUT
 
       - name: apply additional changes and fixes

--- a/.github/workflows/dependencies.yml
+++ b/.github/workflows/dependencies.yml
@@ -18,7 +18,7 @@ jobs:
         id: check_for_outdated_dependencies
         run: |
           body=$(poetry show -o -n)
-          echo ::set-output name="body::$body"
+          echo "body=$body" >> $GITHUB_OUTPUT
 
       - name: Format PR message
         if: ${{ steps.check_for_outdated_dependencies.outputs.body != 0 }}
@@ -35,7 +35,7 @@ jobs:
           body="${body//'%'/'%25'}"
           body="${body//$'\n'/'%0A'}"
           body="${body//$'\r'/'%0D'}"
-          echo ::set-output name="body::$body"
+          echo "body=$body" >> $GITHUB_OUTPUT
 
       - name: Update outdated packages
         if: ${{ steps.check_for_outdated_dependencies.outputs.body != 0 }}

--- a/.github/workflows/dependencies.yml
+++ b/.github/workflows/dependencies.yml
@@ -17,7 +17,7 @@ jobs:
       - name: Gather outdated dependencies
         id: check_for_outdated_dependencies
         run: |
-          body=$(poetry show -o -n)
+          body="$(poetry show -o -n)"
           echo "body=$body" >> $GITHUB_OUTPUT
 
       - name: Format PR message

--- a/.github/workflows/dependencies.yml
+++ b/.github/workflows/dependencies.yml
@@ -18,7 +18,7 @@ jobs:
         id: check_for_outdated_dependencies
         run: |
           body="$(poetry show -o -n)"
-          echo "body=$body" >> $GITHUB_OUTPUT
+          echo "body=$body" >> "$GITHUB_OUTPUT"
 
       - name: Format PR message
         if: ${{ steps.check_for_outdated_dependencies.outputs.body != 0 }}
@@ -35,7 +35,7 @@ jobs:
           body="${body//'%'/'%25'}"
           body="${body//$'\n'/'%0A'}"
           body="${body//$'\r'/'%0D'}"
-          echo "body=$body" >> $GITHUB_OUTPUT
+          echo "body=$body" >> "$GITHUB_OUTPUT"
 
       - name: Update outdated packages
         if: ${{ steps.check_for_outdated_dependencies.outputs.body != 0 }}

--- a/.github/workflows/draft_release.yml
+++ b/.github/workflows/draft_release.yml
@@ -20,7 +20,7 @@ jobs:
         run: |
           poetry version ${{ github.event.inputs.version }}
           version=$(poetry version --short)
-          echo ::set-output name="version::$version"
+          echo "version=$version" >> $GITHUB_OUTPUT
       - name: Update changelog
         id: changelog
         shell: bash
@@ -31,7 +31,7 @@ jobs:
           body="${body//'%'/'%25'}"
           body="${body//$'\n'/'%0A'}"
           body="${body//$'\r'/'%0D'}"
-          echo ::set-output name="body::$body"
+          echo "body=$body" >> $GITHUB_OUTPUT
       - name: Commit changes
         uses: EndBug/add-and-commit@v7
         with:

--- a/.github/workflows/draft_release.yml
+++ b/.github/workflows/draft_release.yml
@@ -20,7 +20,7 @@ jobs:
         run: |
           poetry version ${{ github.event.inputs.version }}
           version="$(poetry version --short)"
-          echo "version=$version" >> $GITHUB_OUTPUT
+          echo "version=$version" >> "$GITHUB_OUTPUT"
       - name: Update changelog
         id: changelog
         shell: bash
@@ -31,7 +31,7 @@ jobs:
           body="${body//'%'/'%25'}"
           body="${body//$'\n'/'%0A'}"
           body="${body//$'\r'/'%0D'}"
-          echo "body=$body" >> $GITHUB_OUTPUT
+          echo "body=$body" >> "$GITHUB_OUTPUT"
       - name: Commit changes
         uses: EndBug/add-and-commit@v7
         with:

--- a/.github/workflows/draft_release.yml
+++ b/.github/workflows/draft_release.yml
@@ -19,7 +19,7 @@ jobs:
         shell: bash
         run: |
           poetry version ${{ github.event.inputs.version }}
-          version=$(poetry version --short)
+          version="$(poetry version --short)"
           echo "version=$version" >> $GITHUB_OUTPUT
       - name: Update changelog
         id: changelog

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -18,6 +18,10 @@ repos:
       - id: mixed-line-ending
       - id: trailing-whitespace
         args: [ --markdown-linebreak-ext=md ]
+  - repo: https://github.com/rhysd/actionlint
+    rev: v1.6.22
+    hooks:
+      - id: actionlint-docker
   - repo: https://github.com/thlorenz/doctoc
     rev: v2.1.0
     hooks:


### PR DESCRIPTION
`::set-output` is deprecated.
See: https://github.blog/changelog/2022-10-11-github-actions-deprecating-save-state-and-set-output-commands/

## Description

A short description about the changes in this pull request. If the pull request is related to some issue, mention it
 here.

## Checklist

- [ ] Tests covering the new functionality have been added
- [ ] Documentation has been updated OR the change is too minor to be documented
- [ ] Changes are listed in the `CHANGELOG.md` OR changes are insignificant
