### PR TITLE
fix: itemcallnumber is actually optional

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,8 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/), and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Fixed
+- itemcallnumber is optional, indeed not all books have that type of identifier
 
 ## [1.4.0] - 2022-12-17
 ### Added

--- a/src/mediathequeroubaix/get_loans/loan.py
+++ b/src/mediathequeroubaix/get_loans/loan.py
@@ -16,7 +16,7 @@ class Loan(BaseModel):
     # 2022-11-19T23:59:00
     date_due: date
     # E BD/FON
-    itemcallnumber: str
+    itemcallnumber: str | None
     # Used to renew: 1234567
     itemnumber: int
     # Boolean

--- a/src/mediathequeroubaix/get_loans/parse_loans_test.py
+++ b/src/mediathequeroubaix/get_loans/parse_loans_test.py
@@ -21,7 +21,8 @@ def test_someloans() -> None:
     assert parse_loans(
         '[{"reasons_not_renewable": "too_many", "biblionumber": 298309, "issuedate": "2022-10-08T14:30:14", '
         '"barcode": "C2500002968", "branchcode": "MED", "itemcallnumber": "E BD/LEG", "date_due": "2022-11-19T23:59:00", "holdingbranch": "M\u00e9diath\u00e8que", "renewable": false, "borrowernumber": 48742, "title": "L\'\u00e9preuve d\'Had\u00e8s", "itemnumber": 360556}, '
-        '{"barcode": "C2100005871", "biblionumber": 287420, "issuedate": "2020-01-02T03:04:05", "itemcallnumber": "R ABC", "date_due": "2020-01-02T03:04:06", "branchcode": "MED", "itemnumber": 341991, "holdingbranch": "M\u00e9diath\u00e8que", "renewable": true, "borrowernumber": 48742, "title": "Le secret d\'H\u00e9racl\u00e8s"}]'
+        '{"barcode": "C2100005871", "biblionumber": 287420, "issuedate": "2020-01-02T03:04:05", "itemcallnumber": '
+        'null, "date_due": "2020-01-02T03:04:06", "branchcode": "MED", "itemnumber": 341991, "holdingbranch": "M\u00e9diath\u00e8que", "renewable": true, "borrowernumber": 48742, "title": "Le secret d\'H\u00e9racl\u00e8s"}]'
     ) == Success(
         [
             Loan(
@@ -39,7 +40,7 @@ def test_someloans() -> None:
                 barcode="C2100005871",
                 issuedate="2020-01-02T03:04:05",
                 date_due="2020-01-02T03:04:06",
-                itemcallnumber="R ABC",
+                itemcallnumber=None,
                 itemnumber=341991,
                 renewable=True,
             ),


### PR DESCRIPTION
## Checklist

- [x] Tests covering the new functionality have been added
- [x] Documentation has been updated OR the change is too minor to be documented
- [x] Changes are listed in the `CHANGELOG.md` OR changes are insignificant
